### PR TITLE
Fix replacement inside await

### DIFF
--- a/src/svelte2tsx.ts
+++ b/src/svelte2tsx.ts
@@ -84,7 +84,7 @@ function processSvelteTemplate(str: MagicString): TemplateProcessResult {
         //rewrite get
         let dollar = str.original.indexOf("$", node.start);
         str.overwrite(dollar, dollar+1, "__sveltets_store_get(");
-        str.appendLeft(node.end, ")")
+        str.prependLeft(node.end, ")")
     }
 
     const resolveStore = (pending: pendingStoreResolution<Node>) => {

--- a/test/svelte2tsx/samples/await-with-$store/expected.tsx
+++ b/test/svelte2tsx/samples/await-with-$store/expected.tsx
@@ -1,0 +1,19 @@
+<></>;import { readable } from 'svelte/store';
+function render() {
+
+	
+	const store = readable(Promise.resolve('test'), () => {});
+;
+<>
+
+{() => {let _$$p = (__sveltets_store_get(store)); <>
+	<p>loading</p>
+</>; _$$p.then((data) => {<>
+	{data}
+</>})}}</>
+return { props: {}, slots: {} }}
+
+export default class {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/test/svelte2tsx/samples/await-with-$store/input.svelte
+++ b/test/svelte2tsx/samples/await-with-$store/input.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { readable } from 'svelte/store';
+	const store = readable(Promise.resolve('test'), () => {});
+</script>
+
+{#await $store}
+	<p>loading</p>
+{:then data}
+	{data}
+{/await}


### PR DESCRIPTION
Use prepend instead of append so that outer replacements that were done with prependLeft come afterwards
Fixes bug where $store inside #await produces invalid jsx
Hopefully helps fixing https://github.com/sveltejs/language-tools/issues/97