### PR TITLE
fix semi issue when a $-variable is in await block

### DIFF
--- a/test/htmlx2jsx/samples/await-block-basic-catch/expected.jsx
+++ b/test/htmlx2jsx/samples/await-block-basic-catch/expected.jsx
@@ -1,4 +1,4 @@
-<>{() => {let _$$p = (somePromise); _$$p.then((value) => {<>
+<>{() => {let _$$p = (somePromise) ;_$$p.then((value) => {<>
     <h1>Promise Resolved</h1>
 </>}).catch(() => {<>
     <h2>Promise Errored</h2>

--- a/test/htmlx2jsx/samples/await-block-basic/expected.jsx
+++ b/test/htmlx2jsx/samples/await-block-basic/expected.jsx
@@ -1,3 +1,3 @@
-<>{() => {let _$$p = (somePromise); _$$p.then((value) => {<>
+<>{() => {let _$$p = (somePromise) ;_$$p.then((value) => {<>
     <h1>Promise Resolved</h1>
 </>})}}</>

--- a/test/htmlx2jsx/samples/await-block-pending-catch/expected.jsx
+++ b/test/htmlx2jsx/samples/await-block-pending-catch/expected.jsx
@@ -1,4 +1,4 @@
-<>{() => {let _$$p = (somePromise); <>
+<>{() => {let _$$p = (somePromise) ;<>
     <h1>Promise Pending</h1>
 </>; _$$p.then((value) => {<>
     <h1>Promise Resolved {value}</h1>

--- a/test/htmlx2jsx/samples/await-block-pending/expected.jsx
+++ b/test/htmlx2jsx/samples/await-block-pending/expected.jsx
@@ -1,4 +1,4 @@
-<>{() => {let _$$p = (somePromise); <>
+<>{() => {let _$$p = (somePromise) ;<>
     <h1>Promise Pending</h1>
 </>; _$$p.then((value) => {<>
     <h1>Promise Resolved {value}</h1>

--- a/test/svelte2tsx/samples/await-block-store/expected.tsx
+++ b/test/svelte2tsx/samples/await-block-store/expected.tsx
@@ -1,0 +1,10 @@
+<></>;function render() {
+<>{() => {let _$$p = (__sveltets_store_get(somePromise)) ;_$$p.then((value) => {<>
+    <h1>Promise Resolved</h1>
+</>})}}</>
+return { props: {}, slots: {} }}
+
+export default class {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/test/svelte2tsx/samples/await-block-store/input.svelte
+++ b/test/svelte2tsx/samples/await-block-store/input.svelte
@@ -1,0 +1,3 @@
+{#await $somePromise then value}
+    <h1>Promise Resolved</h1>
+{/await}


### PR DESCRIPTION
we have an issue when awaiting a $ prefixed store variable in await block
https://github.com/sveltejs/language-tools/issues/97

This code 

```svelte
<script>
	import { readable } from 'svelte/store';
	const store = readable(Promise.resolve('test'), () => {});
</script>

{#await $store}
	<p>loading</p>
{:then data}
	{data}
{/await}
```

get transform into this:

```tsx
{() => {let _$$p = (__sveltets_store_get(store);) <>
  <p>loading</p>
</> _$$p.then((data) => {<>
  {data}
</>})}}
</>
return { props: {}, slots: {} }}
```
I think it could be fix by moving semi to when adding `<>` or `_$$p.then` like prettier does. What do you thinks? it's it ok?