### PR TITLE
script and style like component

### DIFF
--- a/test/svelte2tsx/samples/script-style-like-component/expected.tsx
+++ b/test/svelte2tsx/samples/script-style-like-component/expected.tsx
@@ -1,0 +1,16 @@
+<></>;function render() {
+
+    let Script, Style;
+;
+<>
+
+<Script>
+    <p></p>
+</Script>
+<Style /></>
+return { props: {}, slots: {} }}
+
+export default class {
+    $$prop_def = __sveltets_partial(render().props)
+    $$slot_def = render().slots
+}

--- a/test/svelte2tsx/samples/script-style-like-component/input.svelte
+++ b/test/svelte2tsx/samples/script-style-like-component/input.svelte
@@ -1,0 +1,8 @@
+<script>
+    let Script, Style;
+</script>
+
+<Script>
+    <p></p>
+</Script>
+<Style />


### PR DESCRIPTION
https://github.com/sveltejs/language-tools/issues/100

`findVerbatimElements` should be case sensitive so that `Script` and `Style` component's child won't be blank out during parsing and they won't be confused actual `script` and `style`